### PR TITLE
Enable support for multiple files being passed to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,21 @@ For Environment variable values we support
 `Deployment StatefulSet` object types
 
 Default `""`
+
+### `dir`
+**Required** The root directory of the base or overlay. Should be one of:
+* kustomize-base
+* overlays/development-eu
+* overlays/staging-eu
+* overlays/production-eu 
+
 ### `filepath`
 **Required** The name of the file that holds the container image name
 
 Expects relative path from the current working directory. 
+
+Multiple files can be specified comma separated, i.e. `packages/deployment-de.yaml,packages/deployment-gb.yaml,packages/deployment-ie.yaml`.
+
 If action/checkout is used it is assumed that working directory is in the root of the cloned project
 
  Default `""`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Default `""`
 * overlays/staging-eu
 * overlays/production-eu 
 
-### `filepath`
+### `files`
 **Required** The name of the file that holds the container image name
 
 Expects relative path from the current working directory. 

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,11 @@ inputs:
     description: 'Name of the container'
     required: true
     default: ''
+  dir:
+    description: 'The root directory of the base or overlay, i.e. overlays/production-eu'
+    required: true
   filepath:
-    description: 'Path to the yaml file'
+    description: 'Comma separated paths to YAML files'
     required: true
     default: ''
 
@@ -35,6 +38,7 @@ runs:
   args:
     - ${{ inputs.mode }}
     - ${{ inputs.container-name }}
+    - ${{ inputs.dir }}
     - ${{ inputs.filepath }}
     - ${{ inputs.new-image-tag }}
     - ${{ inputs.env-name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,173 +3,182 @@
 SUPPORTED_MODES=(ENV_VAR IMAGE_TAG)
 MODE=$1
 CONTAINER_NAME=$2
-FILEPATH=$3
-NEW_IMAGE_TAG=$4
-ENV_NAME=$5
-NEW_ENV_VALUE=$6
+DIR=$3
+FILES=$4
+NEW_IMAGE_TAG=$5
+ENV_NAME=$6
+NEW_ENV_VALUE=$7
 
 if [[ ! " ${SUPPORTED_MODES[@]} " =~ " ${MODE} " ]]; then
   echo " +++++++++ ERROR MODE \"${MODE}\" is not part of the supported values [ ${SUPPORTED_MODES[@]} ] " >&2
   exit 1
 fi
 
-if test -f "${FILEPATH}"; then
-  echo " +++ + Updating file ${FILEPATH}"
-else
-  echo " +++++++++ ERROR file \"${FILEPATH}\" does not exist" >&2
-  exit 1
-fi
+# Ensure DIR has trailing slash
+[[ "${DIR}" != */ ]] && DIR="${DIR}/"
 
+IFS=","
+for file in $FILES; do
+  FILEPATH="${DIR}${file}"
 
-if [[ ${MODE} == "IMAGE_TAG" ]]; then
-  SUPPORTED_OBJECT_KINDS=(Deployment StatefulSet CronJob Kustomization)
-  if [ -z "${NEW_IMAGE_TAG}" ]; then
-    echo " +++++++++ ERROR NEW_IMAGE_TAG  \"${NEW_IMAGE_TAG}\" is not correct " >&2
+  if test -f "${FILEPATH}"; then
+    echo " +++ + Updating file ${FILEPATH}"
+  else
+    echo " +++++++++ ERROR file \"${FILEPATH}\" does not exist" >&2
     exit 1
   fi
 
-  objectKind=$(yq r ${FILEPATH} kind)
-  echo " +++ + Detected Object kind as \"${objectKind}\" "
 
-  if [[ ! " ${SUPPORTED_OBJECT_KINDS[@]} " =~ " ${objectKind} " ]]; then
-    echo " +++++++++ ERROR Object kind \"${objectKind}\" is not part of the supported values [ ${SUPPORTED_OBJECT_KINDS[@]} ] for file ${FILEPATH} " >&2
-    exit 1
-  fi
-
-  if [[ ${objectKind} == "Deployment" ]] || [[ ${objectKind} == "StatefulSet" ]] ; then
-    containerPosition=$(yq r ${FILEPATH} spec.template.spec.containers.*.name | grep -n ${CONTAINER_NAME}$ | cut -d: -f1)
-    containerIndex=$((${containerPosition/M/}-1))
-    if (( ${containerIndex} < 0 )) ; then
-      echo " +++++++++ ERROR container with name ${CONTAINER_NAME} could not be found in file  ${FILEPATH}" >&2
+  if [[ ${MODE} == "IMAGE_TAG" ]]; then
+    SUPPORTED_OBJECT_KINDS=(Deployment StatefulSet CronJob Kustomization)
+    if [ -z "${NEW_IMAGE_TAG}" ]; then
+      echo " +++++++++ ERROR NEW_IMAGE_TAG  \"${NEW_IMAGE_TAG}\" is not correct " >&2
       exit 1
     fi
 
-    echo " +++ + Container Index $containerIndex"
-    currentImageValue=$(yq r ${FILEPATH} spec.template.spec.containers[${containerIndex}].image)
-    if [[ ${currentImageValue} == "null" ]]; then
-      echo " +++++++++ ERROR Cannot find image field for container named  ${CONTAINER_NAME} in file ${FILEPATH} " >&2
-      exit 1
-    fi
-    ocurrancesCount=$(grep -o "$currentImageValue" ${FILEPATH} | wc -l)
-    if (( ${ocurrancesCount} > 1 )); then
-      echo " +++++++++ ERROR Cannot update file ${FILEPATH}  as there are multiple occurrences of tag ${currentImageValue}" >&2
-      exit 1
-    fi
-    echo " +++ + + Processing image from $currentImageValue"
+    objectKind=$(yq r ${FILEPATH} kind)
+    echo " +++ + Detected Object kind as \"${objectKind}\" "
 
-    imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
-    if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
-    echo " +++ + + to new  image  tag    ${imageFullName}:${NEW_IMAGE_TAG}"
-    sed -i "s+${currentImageValue}+${imageFullName}:${NEW_IMAGE_TAG}+g" ${FILEPATH}
-  fi
-
-  if [[ ${objectKind} == "CronJob" ]] ; then
-    containerPosition=$(yq r ${FILEPATH} spec.jobTemplate.spec.template.spec.containers.*.name | grep -n ${CONTAINER_NAME}$ | cut -d: -f1)
-    containerIndex=$((${containerPosition/M/}-1))
-    if (( ${containerIndex} < 0 )); then
-      echo " +++++++++ ERROR container with name ${CONTAINER_NAME} could not be found in file CronJob  ${FILEPATH}" >&2
+    if [[ ! " ${SUPPORTED_OBJECT_KINDS[@]} " =~ " ${objectKind} " ]]; then
+      echo " +++++++++ ERROR Object kind \"${objectKind}\" is not part of the supported values [ ${SUPPORTED_OBJECT_KINDS[@]} ] for file ${FILEPATH} " >&2
       exit 1
     fi
 
-    echo " +++ + Container Index in CronJob $containerIndex"
-    currentImageValue=$(yq r ${FILEPATH} spec.jobTemplate.spec.template.spec.containers[${containerIndex}].image)
-    if [[ ${currentImageValue} == "null" ]]; then
-      echo " +++++++++ ERROR Cannot find image field for container named  ${CONTAINER_NAME} in file ${FILEPATH} " >&2
-      exit 1
+    if [[ ${objectKind} == "Deployment" ]] || [[ ${objectKind} == "StatefulSet" ]] ; then
+      containerPosition=$(yq r ${FILEPATH} spec.template.spec.containers.*.name | grep -n ${CONTAINER_NAME}$ | cut -d: -f1)
+      containerIndex=$((${containerPosition/M/}-1))
+      if (( ${containerIndex} < 0 )) ; then
+        echo " +++++++++ ERROR container with name ${CONTAINER_NAME} could not be found in file  ${FILEPATH}" >&2
+        exit 1
+      fi
+
+      echo " +++ + Container Index $containerIndex"
+      currentImageValue=$(yq r ${FILEPATH} spec.template.spec.containers[${containerIndex}].image)
+      if [[ ${currentImageValue} == "null" ]]; then
+        echo " +++++++++ ERROR Cannot find image field for container named  ${CONTAINER_NAME} in file ${FILEPATH} " >&2
+        exit 1
+      fi
+      ocurrancesCount=$(grep -o "$currentImageValue" ${FILEPATH} | wc -l)
+      if (( ${ocurrancesCount} > 1 )); then
+        echo " +++++++++ ERROR Cannot update file ${FILEPATH}  as there are multiple occurrences of tag ${currentImageValue}" >&2
+        exit 1
+      fi
+      echo " +++ + + Processing image from $currentImageValue"
+
+      imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
+      if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
+      echo " +++ + + to new  image  tag    ${imageFullName}:${NEW_IMAGE_TAG}"
+      sed -i "s+${currentImageValue}+${imageFullName}:${NEW_IMAGE_TAG}+g" ${FILEPATH}
     fi
-    ocurrancesCount=$(grep -o "$currentImageValue" ${FILEPATH} | wc -l)
-    if (( ${ocurrancesCount} > 1 )); then
-      echo " +++++++++ ERROR Cannot update file ${FILEPATH}  as there are multiple occurrences of tag ${currentImageValue}" >&2
-      exit 1
+
+    if [[ ${objectKind} == "CronJob" ]] ; then
+      containerPosition=$(yq r ${FILEPATH} spec.jobTemplate.spec.template.spec.containers.*.name | grep -n ${CONTAINER_NAME}$ | cut -d: -f1)
+      containerIndex=$((${containerPosition/M/}-1))
+      if (( ${containerIndex} < 0 )); then
+        echo " +++++++++ ERROR container with name ${CONTAINER_NAME} could not be found in file CronJob  ${FILEPATH}" >&2
+        exit 1
+      fi
+
+      echo " +++ + Container Index in CronJob $containerIndex"
+      currentImageValue=$(yq r ${FILEPATH} spec.jobTemplate.spec.template.spec.containers[${containerIndex}].image)
+      if [[ ${currentImageValue} == "null" ]]; then
+        echo " +++++++++ ERROR Cannot find image field for container named  ${CONTAINER_NAME} in file ${FILEPATH} " >&2
+        exit 1
+      fi
+      ocurrancesCount=$(grep -o "$currentImageValue" ${FILEPATH} | wc -l)
+      if (( ${ocurrancesCount} > 1 )); then
+        echo " +++++++++ ERROR Cannot update file ${FILEPATH}  as there are multiple occurrences of tag ${currentImageValue}" >&2
+        exit 1
+      fi
+      echo " +++ + + Processing image from $currentImageValue"
+
+      imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
+      if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
+      echo " +++ + + to new  image  tag    ${imageFullName}:${NEW_IMAGE_TAG}"
+      sed -i "s+${currentImageValue}+${imageFullName}:${NEW_IMAGE_TAG}+g" ${FILEPATH}
     fi
-    echo " +++ + + Processing image from $currentImageValue"
-
-    imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
-    if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
-    echo " +++ + + to new  image  tag    ${imageFullName}:${NEW_IMAGE_TAG}"
-    sed -i "s+${currentImageValue}+${imageFullName}:${NEW_IMAGE_TAG}+g" ${FILEPATH}
-  fi
 
 
-  if [[ ${objectKind} == "Kustomization" ]] ; then
-    kustomizeBuildPath="${FILEPATH%/*}"
-    echo " +++ + Building kustomize in directory ${kustomizeBuildPath}"
-    fullKustomizeBuild=$(kustomize build ${kustomizeBuildPath})
+    if [[ ${objectKind} == "Kustomization" ]] ; then
+      kustomizeBuildPath="${FILEPATH%/*}"
+      echo " +++ + Building kustomize in directory ${kustomizeBuildPath}"
+      fullKustomizeBuild=$(kustomize build ${kustomizeBuildPath})
 
-    delimiter="---"
-    s=$fullKustomizeBuild$delimiter
-    kustomizeImageNameToUpdate=""
-    while [[ $s ]]; do
-        object="${s%%"$delimiter"*}"
-        containerPosition=$(echo "$object" | yq r - spec.template.spec.containers.*.name | grep -n ${CONTAINER_NAME}$ | cut -d: -f1)
-        if [[ $containerPosition ]]; then
-          containerIndex=$((${containerPosition/M/}-1))
-          currentImageValue=$(echo "$object" | yq r - spec.template.spec.containers[${containerIndex}].image)
-          if [[ ! $currentImageValue ]]; then
-            currentImageValue=$(echo "$object" | yq r - spec.jobTemplate.spec.template.spec.containers[${containerIndex}].image)
+      delimiter="---"
+      s=$fullKustomizeBuild$delimiter
+      kustomizeImageNameToUpdate=""
+      while [[ $s ]]; do
+          object="${s%%"$delimiter"*}"
+          containerPosition=$(echo "$object" | yq r - spec.template.spec.containers.*.name | grep -n ${CONTAINER_NAME}$ | cut -d: -f1)
+          if [[ $containerPosition ]]; then
+            containerIndex=$((${containerPosition/M/}-1))
+            currentImageValue=$(echo "$object" | yq r - spec.template.spec.containers[${containerIndex}].image)
+            if [[ ! $currentImageValue ]]; then
+              currentImageValue=$(echo "$object" | yq r - spec.jobTemplate.spec.template.spec.containers[${containerIndex}].image)
+            fi
+            imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
+            if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
+            kustomizeImageNameToUpdate=${imageFullName}
           fi
-          imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
-          if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
-          kustomizeImageNameToUpdate=${imageFullName}
-        fi
-        s=${s#*"$delimiter"};
-    done;
+          s=${s#*"$delimiter"};
+      done;
 
-    if [[ ! $kustomizeImageNameToUpdate ]]; then
-      echo " +++++++++ ERROR container with name ${CONTAINER_NAME} could not be found in any file build by kustomize from folder ${kustomizeBuildPath}" >&2
-      exit 1
+      if [[ ! $kustomizeImageNameToUpdate ]]; then
+        echo " +++++++++ ERROR container with name ${CONTAINER_NAME} could not be found in any file build by kustomize from folder ${kustomizeBuildPath}" >&2
+        exit 1
+      fi
+
+      kustomizeImageNamePosition=$(yq r ${FILEPATH} images.*.name | grep -n ${kustomizeImageNameToUpdate} | cut -d: -f1)
+      kustomizeContainerIndex=$((${kustomizeImageNamePosition/M/}-1))
+      kustomizeCurrentNewTagValue=$(yq r ${FILEPATH} images[${kustomizeContainerIndex}].newTag)
+      ocurrancesCount=$(grep -o "$kustomizeCurrentNewTagValue" ${FILEPATH} | wc -l)
+      if (( ${ocurrancesCount} > 1 )); then
+        echo " +++++++++ ERROR Cannot update file ${FILEPATH}  as there are multiple occurrences of string ${kustomizeCurrentNewTagValue}" >&2
+        exit 1
+      fi
+      echo " +++ + + Processing newTag for image name: $kustomizeImageNameToUpdate"
+      echo " +++ + + + from newTag: ${kustomizeCurrentNewTagValue}"
+      echo " +++ + + + to   newTag: ${NEW_IMAGE_TAG}"
+      sed -i "s+${kustomizeCurrentNewTagValue}+${NEW_IMAGE_TAG}+g" ${FILEPATH}
     fi
-
-    kustomizeImageNamePosition=$(yq r ${FILEPATH} images.*.name | grep -n ${kustomizeImageNameToUpdate} | cut -d: -f1)
-    kustomizeContainerIndex=$((${kustomizeImageNamePosition/M/}-1))
-    kustomizeCurrentNewTagValue=$(yq r ${FILEPATH} images[${kustomizeContainerIndex}].newTag)
-    ocurrancesCount=$(grep -o "$kustomizeCurrentNewTagValue" ${FILEPATH} | wc -l)
-    if (( ${ocurrancesCount} > 1 )); then
-      echo " +++++++++ ERROR Cannot update file ${FILEPATH}  as there are multiple occurrences of string ${kustomizeCurrentNewTagValue}" >&2
-      exit 1
-    fi
-    echo " +++ + + Processing newTag for image name: $kustomizeImageNameToUpdate"
-    echo " +++ + + + from newTag: ${kustomizeCurrentNewTagValue}"
-    echo " +++ + + + to   newTag: ${NEW_IMAGE_TAG}"
-    sed -i "s+${kustomizeCurrentNewTagValue}+${NEW_IMAGE_TAG}+g" ${FILEPATH}
-  fi
-fi
-
-if [[ ${MODE} == "ENV_VAR" ]]; then
-  SUPPORTED_OBJECT_KINDS=(Deployment StatefulSet)
-  objectKind=$(yq r ${FILEPATH} kind)
-  echo " +++ + Detected Object kind as \"${objectKind}\" "
-
-  if [[ ! " ${SUPPORTED_OBJECT_KINDS[@]} " =~ " ${objectKind} " ]]; then
-    echo " +++++++++ ERROR Object kind \"${objectKind}\" is not part of the supported values [ ${SUPPORTED_OBJECT_KINDS[@]} ] for file ${FILEPATH} " >&2
-    exit 1
   fi
 
-  if [[ ${objectKind} == "Deployment" ]] || [[ ${objectKind} == "StatefulSet" ]] ; then
-    containerPosition=$(yq r ${FILEPATH} spec.template.spec.containers.*.name | grep -n ${CONTAINER_NAME}$ | cut -d: -f1)
-    containerIndex=$((${containerPosition/M/}-1))
-    if (( ${containerIndex} < 0 )); then
-      echo " +++++++++ ERROR container with name ${CONTAINER_NAME} could not be found in file  ${FILEPATH}" >&2
+  if [[ ${MODE} == "ENV_VAR" ]]; then
+    SUPPORTED_OBJECT_KINDS=(Deployment StatefulSet)
+    objectKind=$(yq r ${FILEPATH} kind)
+    echo " +++ + Detected Object kind as \"${objectKind}\" "
+
+    if [[ ! " ${SUPPORTED_OBJECT_KINDS[@]} " =~ " ${objectKind} " ]]; then
+      echo " +++++++++ ERROR Object kind \"${objectKind}\" is not part of the supported values [ ${SUPPORTED_OBJECT_KINDS[@]} ] for file ${FILEPATH} " >&2
       exit 1
     fi
 
-    echo " +++ + Container Index $containerIndex"
-    envPosition=$(yq r ${FILEPATH} spec.template.spec.containers[${containerIndex}].env[*].name | grep -n ${ENV_NAME}$ | cut -d: -f1)
-    envIndex=$((${envPosition/M/}-1))
-    if (( ${envIndex} < 0 )); then
-      echo " +++++++++ ERROR Environment variable with name ${ENV_NAME} not found in ${CONTAINER_NAME}" >&2
-      exit 1
+    if [[ ${objectKind} == "Deployment" ]] || [[ ${objectKind} == "StatefulSet" ]] ; then
+      containerPosition=$(yq r ${FILEPATH} spec.template.spec.containers.*.name | grep -n ${CONTAINER_NAME}$ | cut -d: -f1)
+      containerIndex=$((${containerPosition/M/}-1))
+      if (( ${containerIndex} < 0 )); then
+        echo " +++++++++ ERROR container with name ${CONTAINER_NAME} could not be found in file  ${FILEPATH}" >&2
+        exit 1
+      fi
+
+      echo " +++ + Container Index $containerIndex"
+      envPosition=$(yq r ${FILEPATH} spec.template.spec.containers[${containerIndex}].env[*].name | grep -n ${ENV_NAME}$ | cut -d: -f1)
+      envIndex=$((${envPosition/M/}-1))
+      if (( ${envIndex} < 0 )); then
+        echo " +++++++++ ERROR Environment variable with name ${ENV_NAME} not found in ${CONTAINER_NAME}" >&2
+        exit 1
+      fi
+      currentEnvValue=$(yq r ${FILEPATH} spec.template.spec.containers[${containerIndex}].env[${envIndex}].value)
+      ocurrancesCount=$(grep -o "$currentEnvValue" ${FILEPATH} | wc -l)
+      if (( ${ocurrancesCount} > 1 )); then
+        echo " +++++++++ ERROR Cannot update file ${FILEPATH}  as there are multiple occurrences of string ${currentEnvValue}" >&2
+        exit 1
+      fi
+      echo " +++ + + Updating ${ENV_NAME} in container ${CONTAINER_NAME} from ${currentEnvValue}"
+      echo " +++ + + To env   ${ENV_NAME} in container ${CONTAINER_NAME} to   ${NEW_ENV_VALUE}"
+      sanitizedOldString=$(echo $currentEnvValue | sed 's/[][`~!@#$%^&*()-+{}\|;:_=",<.>/?'"'"']/\\&/g')
+      sanitizedNewString=$(echo $NEW_ENV_VALUE | sed 's/[][`~!@#$%^&*()-+{}\|;:_=",<.>/?'"'"']/\\&/g')
+      sed -i "s+${sanitizedOldString}+${sanitizedNewString}+g" ${FILEPATH}
     fi
-    currentEnvValue=$(yq r ${FILEPATH} spec.template.spec.containers[${containerIndex}].env[${envIndex}].value)
-    ocurrancesCount=$(grep -o "$currentEnvValue" ${FILEPATH} | wc -l)
-    if (( ${ocurrancesCount} > 1 )); then
-      echo " +++++++++ ERROR Cannot update file ${FILEPATH}  as there are multiple occurrences of string ${currentEnvValue}" >&2
-      exit 1
-    fi
-    echo " +++ + + Updating ${ENV_NAME} in container ${CONTAINER_NAME} from ${currentEnvValue}"
-    echo " +++ + + To env   ${ENV_NAME} in container ${CONTAINER_NAME} to   ${NEW_ENV_VALUE}"
-    sanitizedOldString=$(echo $currentEnvValue | sed 's/[][`~!@#$%^&*()-+{}\|;:_=",<.>/?'"'"']/\\&/g')
-    sanitizedNewString=$(echo $NEW_ENV_VALUE | sed 's/[][`~!@#$%^&*()-+{}\|;:_=",<.>/?'"'"']/\\&/g')
-    sed -i "s+${sanitizedOldString}+${sanitizedNewString}+g" ${FILEPATH}
-  fi
-fi
+  fi;
+done


### PR DESCRIPTION
The diff looks really messy because most of the script has been indented, due to wrapping it in a for loop: 

```
# Ensure DIR has trailing slash
[[ "${DIR}" != */ ]] && DIR="${DIR}/"

IFS=","
for file in $FILES; do
  FILEPATH="${DIR}${file}"
  ...
```

This enables us to use the action to update multiple files, to support the shared gitops action. This is a breaking change and must be bumped to 2.0. TODO: figure out how.

Related PRs:
https://github.com/loveholidays/github-actions/pull/6
https://github.com/loveholidays/backend/pull/5387
