### PR TITLE
support helm cronjobs image update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN wget -nv https://github.com/mikefarah/yq/releases/download/2.1.1/yq_linux_am
     curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash && \
     mv kustomize /usr/local/bin/kustomize
 
+# install yq v4
+RUN wget -nv https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64 && \
+    chmod 744 yq_linux_amd64 && \
+    mv yq_linux_amd64 /usr/local/bin/yq4
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,8 @@ FILES=$3
 NEW_IMAGE_TAG=$4
 ENV_NAME=$5
 NEW_ENV_VALUE=$6
-HELM_IMAGE_KEY="image.tag"
+HELM_IMAGE_KEY=".image.tag"
+HELM_CRONJOB_IMAGE_KEY=".cronJobs.*.image.tag"
 
 if [[ ! " ${SUPPORTED_MODES[@]} " =~ " ${MODE} " ]]; then
   echo " +++++++++ ERROR MODE \"${MODE}\" is not part of the supported values [ ${SUPPORTED_MODES[@]} ] " >&2
@@ -163,7 +164,11 @@ for FILEPATH in $FILES; do
   fi;
 
   if [[ ${MODE} == "HELM_VALUES" ]]; then
-    yq w -i ${FILEPATH} ${HELM_IMAGE_KEY} "\"${NEW_IMAGE_TAG}\""
+    if yq4 'has("cronJobs")' "${FILEPATH}" 2>/dev/null; then
+      yq4 "${HELM_CRONJOB_IMAGE_KEY} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+    else
+      yq4 "${HELM_IMAGE_KEY} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+    fi
     echo "+++ + + Updated ${HELM_IMAGE_KEY} key in ${FILEPATH} to ${NEW_IMAGE_TAG}"
   fi
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -166,7 +166,8 @@ for FILEPATH in $FILES; do
   if [[ ${MODE} == "HELM_VALUES" ]]; then
     if yq4 'has("cronJobs")' "${FILEPATH}" 2>/dev/null; then
       yq4 "${HELM_CRONJOB_IMAGE_KEY} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
-    else
+    fi
+    if yq4 'has("image")' "${FILEPATH}" 2>/dev/null; then
       yq4 "${HELM_IMAGE_KEY} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
     fi
     echo "+++ + + Updated ${HELM_IMAGE_KEY} key in ${FILEPATH} to ${NEW_IMAGE_TAG}"


### PR DESCRIPTION
[request](https://loveholidays.slack.com/archives/C0K4MBMGA/p1694080696645579)
we have problem with updating cronjobs image tag [example](https://github.com/loveholidays/flux/blob/master/overlays/development-eu/packages/gcs-archive-compress/values.yaml)
yq v2 is so limited, I added yq v4 along with it and kept v2 for backward compatibility 
I tested locally; it should now update` image.tag `and `cronJobs.*.image.tag` and doesn't add a new key if doesn't exists before 