### PR TITLE
fix: update Helm values for multi-container pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 *.iml
 tmp/
+.worktree/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ For docker container image tag we support
 For Environment variable values we support
 `Deployment StatefulSet` object types
 
+For Helm values files (HELM_VALUES mode), the action supports:
+- Default container images (`.image.tag`)
+- Additional containers (`.containers.<container-name>.image.tag`)
+- CronJob images (`.cronJobs.*.image.tag` or `.cronJobs.<container-name>.image.tag`)
+
+The action automatically detects whether you're updating the default container or an additional container by reading the `containerName` field from the Helm values file.
+
 Default `""`
 
 ### `files`
@@ -58,30 +65,69 @@ none
 
 ## Example usage
 
-      - name: Update image tag for container nginx in deployment.yaml
-        uses: loveholidays/gitops-action-yaml-updater@v1.0
-        with:
-          mode: IMAGE_TAG
-          container-name: nginx
-          new-image-tag: prod-${{ steps.your-previous-step-id.outputs.GITHUB_SHORT_SHA }}
-          dir: overlays/development-eu
-          files: deployment.yaml
+### IMAGE_TAG mode - Update Kubernetes Deployment
 
-      - name: Update image tag for container bridge in two files
-        uses: loveholidays/gitops-action-yaml-updater@v1.0
-        with:
-          mode: IMAGE_TAG
-          container-name: nginx
-          new-image-tag: prod-${{ steps.your-previous-step-id.outputs.GITHUB_SHORT_SHA }}
-          dir: kustomize-base
-          files: "web/bridge/deployment.yaml,web/bridge-api/deployment.yaml"
+```yaml
+- name: Update image tag for container nginx in deployment.yaml
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  with:
+    mode: IMAGE_TAG
+    container-name: nginx
+    new-image-tag: prod-${{ steps.your-previous-step-id.outputs.GITHUB_SHORT_SHA }}
+    files: overlays/development-eu/deployment.yaml
+```
 
-      - name: Update MY_GITHUB_SHORT_SHA env value for nginx container
-        uses: loveholidays/gitops-action-yaml-updater@v1.0
-        with:
-          mode: ENV_VAR
-          container-name: nginx
-          env-name: MY_GITHUB_SHORT_SHA
-          new-env-value: ${{ steps.your-previous-step-id.outputs.GITHUB_SHORT_SHA }}
-          dir: overlays/development-eu
-          files: deployment.yaml
+### IMAGE_TAG mode - Update multiple files
+
+```yaml
+- name: Update image tag for container bridge in two files
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  with:
+    mode: IMAGE_TAG
+    container-name: nginx
+    new-image-tag: prod-${{ steps.your-previous-step-id.outputs.GITHUB_SHORT_SHA }}
+    files: "web/bridge/deployment.yaml,web/bridge-api/deployment.yaml"
+```
+
+### ENV_VAR mode - Update environment variable
+
+```yaml
+- name: Update MY_GITHUB_SHORT_SHA env value for nginx container
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  with:
+    mode: ENV_VAR
+    container-name: nginx
+    env-name: MY_GITHUB_SHORT_SHA
+    new-env-value: ${{ steps.your-previous-step-id.outputs.GITHUB_SHORT_SHA }}
+    files: overlays/development-eu/deployment.yaml
+```
+
+### HELM_VALUES mode - Update default container
+
+```yaml
+- name: Update default container image in Helm values
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  with:
+    mode: HELM_VALUES
+    container-name: my-app
+    new-image-tag: v1.2.3
+    files: overlays/production/values.yaml
+```
+
+### HELM_VALUES mode - Update additional container (multi-container pod)
+
+```yaml
+- name: Update additional container image in Helm values
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  with:
+    mode: HELM_VALUES
+    container-name: sidecar-ui
+    new-image-tag: v2.0.0
+    files: overlays/production/values.yaml
+```
+
+This will update `.containers.sidecar-ui.image.tag` in your Helm values file.
+
+## Testing
+
+The action includes a comprehensive test suite. See [tests/README.md](tests/README.md) for details on running tests.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ none
 
 ```yaml
 - name: Update image tag for container nginx in deployment.yaml
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
   with:
     mode: IMAGE_TAG
     container-name: nginx
@@ -81,7 +81,7 @@ none
 
 ```yaml
 - name: Update image tag for container bridge in two files
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
   with:
     mode: IMAGE_TAG
     container-name: nginx
@@ -93,7 +93,7 @@ none
 
 ```yaml
 - name: Update MY_GITHUB_SHORT_SHA env value for nginx container
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
   with:
     mode: ENV_VAR
     container-name: nginx
@@ -106,7 +106,7 @@ none
 
 ```yaml
 - name: Update default container image in Helm values
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
   with:
     mode: HELM_VALUES
     container-name: my-app
@@ -118,7 +118,7 @@ none
 
 ```yaml
 - name: Update additional container image in Helm values
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.2
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
   with:
     mode: HELM_VALUES
     container-name: sidecar-ui

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/loveholidays/gitops-action-yaml-updater:v1.8.2'
+  image: 'docker://ghcr.io/loveholidays/gitops-action-yaml-updater:v1.8.3'
   args:
     - ${{ inputs.mode }}
     - ${{ inputs.container-name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -164,12 +164,55 @@ for FILEPATH in $FILES; do
   fi;
 
   if [[ ${MODE} == "HELM_VALUES" ]]; then
+    # Read the default container name from the values file
+    defaultContainerName=$(yq4 '.containerName // ""' "${FILEPATH}")
+
+    # Determine if we're updating the default container or an additional container
+    if [[ -n "${defaultContainerName}" ]] && [[ "${CONTAINER_NAME}" == "${defaultContainerName}" ]]; then
+      # Updating the default container
+      targetImageKey=".image.tag"
+      targetCronJobKey=".cronJobs.*.image.tag"
+      echo " +++ + Updating default container: ${CONTAINER_NAME}"
+    elif [[ -z "${defaultContainerName}" ]]; then
+      # No default container name specified, assume default paths
+      targetImageKey=".image.tag"
+      targetCronJobKey=".cronJobs.*.image.tag"
+      echo " +++ + No default container name found, using default paths"
+    else
+      # Updating an additional container
+      targetImageKey=".containers.${CONTAINER_NAME}.image.tag"
+      targetCronJobKey=".cronJobs.${CONTAINER_NAME}.image.tag"
+      echo " +++ + Updating additional container: ${CONTAINER_NAME}"
+    fi
+
+    # Update cronJobs if present
     if [[ $(yq4 'has("cronJobs")' "${FILEPATH}" 2>/dev/null) == "true" ]]; then
-      yq4 "${HELM_CRONJOB_IMAGE_KEY} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+      yq4 "${targetCronJobKey} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+      echo " +++ + + Updated cronJob: ${targetCronJobKey}"
     fi
-    if [[ $(yq4 'has("image")' "${FILEPATH}" 2>/dev/null) == "true" ]]; then
-      yq4 "${HELM_IMAGE_KEY} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+
+    # Update image if present (for default container) or containers.<name> (for additional)
+    if [[ -n "${defaultContainerName}" ]] && [[ "${CONTAINER_NAME}" == "${defaultContainerName}" ]]; then
+      # Default container - check for .image
+      if [[ $(yq4 'has("image")' "${FILEPATH}" 2>/dev/null) == "true" ]]; then
+        yq4 "${targetImageKey} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+        echo " +++ + + Updated ${targetImageKey} in ${FILEPATH} to ${NEW_IMAGE_TAG}"
+      fi
+    elif [[ -z "${defaultContainerName}" ]]; then
+      # No container name specified, use default behavior
+      if [[ $(yq4 'has("image")' "${FILEPATH}" 2>/dev/null) == "true" ]]; then
+        yq4 "${targetImageKey} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+        echo " +++ + + Updated ${targetImageKey} in ${FILEPATH} to ${NEW_IMAGE_TAG}"
+      fi
+    else
+      # Additional container - check for .containers.<name>
+      if [[ $(yq4 "has(\"containers.${CONTAINER_NAME}\")" "${FILEPATH}" 2>/dev/null) == "true" ]]; then
+        yq4 "${targetImageKey} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+        echo " +++ + + Updated ${targetImageKey} in ${FILEPATH} to ${NEW_IMAGE_TAG}"
+      else
+        echo " +++++++++ ERROR: Container ${CONTAINER_NAME} not found in ${FILEPATH}" >&2
+        exit 1
+      fi
     fi
-    echo "+++ + + Updated ${HELM_IMAGE_KEY} key in ${FILEPATH} to ${NEW_IMAGE_TAG}"
   fi
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,9 +18,6 @@ FILES=$3
 NEW_IMAGE_TAG=$4
 ENV_NAME=$5
 NEW_ENV_VALUE=$6
-HELM_IMAGE_KEY=".image.tag"
-HELM_CRONJOB_IMAGE_KEY=".cronJobs.*.image.tag"
-
 if [[ ! " ${SUPPORTED_MODES[@]} " =~ " ${MODE} " ]]; then
   echo " +++++++++ ERROR MODE \"${MODE}\" is not part of the supported values [ ${SUPPORTED_MODES[@]} ] " >&2
   exit 1
@@ -198,8 +195,15 @@ for FILEPATH in $FILES; do
 
     # Update cronJobs if present
     if [[ $(yq4 'has("cronJobs")' "${FILEPATH}" 2>/dev/null) == "true" ]]; then
-      yq4 "${targetCronJobKey} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
-      echo " +++ + + Updated cronJob: ${targetCronJobKey}"
+      if [[ -n "${defaultContainerName}" ]] && [[ "${CONTAINER_NAME}" != "${defaultContainerName}" ]]; then
+        if [[ $(yq4 ".cronJobs | has(\"${CONTAINER_NAME}\")" "${FILEPATH}" 2>/dev/null) == "true" ]]; then
+          yq4 "${targetCronJobKey} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+          echo " +++ + + Updated cronJob: ${targetCronJobKey}"
+        fi
+      else
+        yq4 "${targetCronJobKey} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
+        echo " +++ + + Updated cronJob: ${targetCronJobKey}"
+      fi
     fi
 
     # Update image if present (for default container) or containers.<name> (for additional)
@@ -217,7 +221,7 @@ for FILEPATH in $FILES; do
       fi
     else
       # Additional container - check for .containers.<name>
-      if [[ $(yq4 "has(\"containers.${CONTAINER_NAME}\")" "${FILEPATH}" 2>/dev/null) == "true" ]]; then
+      if [[ $(yq4 "has(\"containers\") and (.containers | has(\"${CONTAINER_NAME}\"))" "${FILEPATH}" 2>/dev/null) == "true" ]]; then
         yq4 "${targetImageKey} = \"${NEW_IMAGE_TAG}\"" -i ${FILEPATH}
         echo " +++ + + Updated ${targetImageKey} in ${FILEPATH} to ${NEW_IMAGE_TAG}"
       else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Cross-platform sed in-place editing
+sed_inplace() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS requires an extension argument (empty string for no backup)
+    sed -i '' "$@"
+  else
+    # Linux/GNU sed
+    sed -i "$@"
+  fi
+}
+
 SUPPORTED_MODES=(ENV_VAR IMAGE_TAG HELM_VALUES)
 MODE=$1
 CONTAINER_NAME=$2
@@ -58,10 +69,10 @@ for FILEPATH in $FILES; do
 
       echo " +++ + + Processing image from $currentImageValue"
 
-      imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
-      if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
+      # Extract image name without tag (everything before ':')
+      imageFullName="${currentImageValue%%:*}"
       echo " +++ + + to new  image  tag    ${imageFullName}:${NEW_IMAGE_TAG}"
-      sed -i "s+${currentImageValue}+${imageFullName}:${NEW_IMAGE_TAG}+g" ${FILEPATH}
+      sed_inplace "s+${currentImageValue}+${imageFullName}:${NEW_IMAGE_TAG}+g" ${FILEPATH}
     fi
 
     if [[ ${objectKind} == "CronJob" ]] ; then
@@ -81,10 +92,10 @@ for FILEPATH in $FILES; do
 
       echo " +++ + + Processing image from $currentImageValue"
 
-      imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
-      if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
+      # Extract image name without tag (everything before ':')
+      imageFullName="${currentImageValue%%:*}"
       echo " +++ + + to new  image  tag    ${imageFullName}:${NEW_IMAGE_TAG}"
-      sed -i "s+${currentImageValue}+${imageFullName}:${NEW_IMAGE_TAG}+g" ${FILEPATH}
+      sed_inplace "s+${currentImageValue}+${imageFullName}:${NEW_IMAGE_TAG}+g" ${FILEPATH}
     fi
 
 
@@ -105,8 +116,8 @@ for FILEPATH in $FILES; do
             if [[ ! $currentImageValue ]]; then
               currentImageValue=$(echo "$object" | yq r - spec.jobTemplate.spec.template.spec.containers[${containerIndex}].image)
             fi
-            imageFullName=$(grep -Po '\K.*?(?=:)' <<< ${currentImageValue})
-            if [ -z "${imageFullName}" ]; then imageFullName=${currentImageValue}; fi
+            # Extract image name without tag (everything before ':')
+            imageFullName="${currentImageValue%%:*}"
             kustomizeImageNameToUpdate=${imageFullName}
           fi
           s=${s#*"$delimiter"};
@@ -124,7 +135,7 @@ for FILEPATH in $FILES; do
       echo " +++ + + Processing newTag for image name: $kustomizeImageNameToUpdate"
       echo " +++ + + + from newTag: ${kustomizeCurrentNewTagValue}"
       echo " +++ + + + to   newTag: ${NEW_IMAGE_TAG}"
-      sed -i "s+${kustomizeCurrentNewTagValue}+${NEW_IMAGE_TAG}+g" ${FILEPATH}
+      sed_inplace "s+${kustomizeCurrentNewTagValue}+${NEW_IMAGE_TAG}+g" ${FILEPATH}
     fi
   fi
 
@@ -159,7 +170,7 @@ for FILEPATH in $FILES; do
       echo " +++ + + To env   ${ENV_NAME} in container ${CONTAINER_NAME} to   ${NEW_ENV_VALUE}"
       sanitizedOldString=$(echo $currentEnvValue | sed 's/[][`~!@#$%^&*()-+{}\|;:_=",<.>/?'"'"']/\\&/g')
       sanitizedNewString=$(echo $NEW_ENV_VALUE | sed 's/[][`~!@#$%^&*()-+{}\|;:_=",<.>/?'"'"']/\\&/g')
-      sed -i "s+${sanitizedOldString}+${sanitizedNewString}+g" ${FILEPATH}
+      sed_inplace "s+${sanitizedOldString}+${sanitizedNewString}+g" ${FILEPATH}
     fi
   fi;
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,114 @@
+# Tests for gitops-action-yaml-updater
+
+This directory contains automated tests for the gitops-action-yaml-updater action.
+
+## Prerequisites
+
+The tests require the following tools to be installed:
+- `bash` (version 4.0 or higher)
+- `yq` (mikefarah/yq version 2.x or 3.x) - Used for IMAGE_TAG mode operations
+- `yq4` (mikefarah/yq version 4.x) - Used for HELM_VALUES mode operations
+- `grep`
+- `sed`
+- `kustomize` (for Kustomization tests)
+
+**Important:** The script requires [mikefarah/yq](https://github.com/mikefarah/yq), not the python-yq or jq-wrapper versions. Check with `yq --version` - it should show "mikefarah/yq".
+
+### Installing Dependencies
+
+**Note:** Due to the specific dependency requirements, running tests in Docker is strongly recommended.
+
+**Using Docker (Recommended):**
+```bash
+# Build the Docker image (includes all dependencies)
+docker build -t gitops-updater .
+
+# Run tests inside the container
+docker run --rm gitops-updater bash -c "cp -r /tests /tmp/tests && cd /tmp && /tmp/tests/run-tests.sh"
+```
+
+**Local installation (Advanced):**
+Only if you need to run tests locally outside Docker:
+```bash
+# Install mikefarah/yq v3 as 'yq'
+wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+chmod +x yq_linux_amd64
+sudo mv yq_linux_amd64 /usr/local/bin/yq
+
+# Install mikefarah/yq v4 as 'yq4'
+wget https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64
+chmod +x yq_linux_amd64
+sudo mv yq_linux_amd64 /usr/local/bin/yq4
+
+# Install kustomize
+curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+sudo mv kustomize /usr/local/bin/
+```
+
+## Running the Tests
+
+**Locally (requires dependencies installed):**
+```bash
+cd tests
+./run-tests.sh
+```
+
+**Using Docker (recommended):**
+```bash
+docker build -t gitops-updater .
+docker run --rm -v $(pwd)/tests:/tests gitops-updater bash -c "cd / && tests/run-tests.sh"
+```
+
+## Test Coverage
+
+The test suite covers the following scenarios:
+
+### IMAGE_TAG Mode
+- Single container Deployment
+- Multi-container Deployment (first container)
+- Multi-container Deployment (second container)
+- CronJob
+- StatefulSet
+
+### ENV_VAR Mode
+- Updating environment variables in StatefulSet
+
+### HELM_VALUES Mode
+- Single container (default container)
+- Multi-container (default container)
+- **Multi-container (additional container)** - This tests the fix for the bug where additional containers weren't being updated correctly
+
+## Test Fixtures
+
+Test fixtures are located in `tests/fixtures/` and include:
+- `deployment-single-container.yaml` - Simple deployment with one container
+- `deployment-multi-container.yaml` - Deployment with multiple containers
+- `helm-values-single-container.yaml` - Helm values with default container only
+- `helm-values-multi-container.yaml` - Helm values with default + additional containers
+- `cronjob.yaml` - CronJob resource
+- `statefulset.yaml` - StatefulSet with environment variables
+
+## Adding New Tests
+
+To add a new test:
+
+1. Create a fixture file in `tests/fixtures/` if needed
+2. Add a new `run_test` call in `run-tests.sh` with:
+   - Test name
+   - Mode (IMAGE_TAG, ENV_VAR, or HELM_VALUES)
+   - Container name
+   - Fixture file path
+   - New value to set
+   - Expected pattern to verify
+   - (Optional) Environment variable name for ENV_VAR mode
+
+Example:
+```bash
+run_test \
+  "Your test description" \
+  "HELM_VALUES" \
+  "container-name" \
+  "${FIXTURES_DIR}/your-fixture.yaml" \
+  "v1.2.3" \
+  "tag: v1.2.3"
+```

--- a/tests/fixtures/cronjob.yaml
+++ b/tests/fixtures/cronjob.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: test-cronjob
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: test-cronjob
+              image: eu.gcr.io/test/cronjob:v1.0.0
+          restartPolicy: OnFailure

--- a/tests/fixtures/deployment-multi-container.yaml
+++ b/tests/fixtures/deployment-multi-container.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          image: eu.gcr.io/test/api:v1.0.0
+          ports:
+            - containerPort: 5000
+        - name: ui
+          image: eu.gcr.io/test/ui:v1.0.0
+          ports:
+            - containerPort: 3000

--- a/tests/fixtures/deployment-single-container.yaml
+++ b/tests/fixtures/deployment-single-container.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: test-app
+          image: eu.gcr.io/test/test-app:v1.0.0
+          ports:
+            - containerPort: 8080

--- a/tests/fixtures/helm-values-multi-container.yaml
+++ b/tests/fixtures/helm-values-multi-container.yaml
@@ -1,0 +1,17 @@
+containerName: api
+image:
+  repository: eu.gcr.io/test/api
+  tag: v1.0.0
+resources:
+  requests:
+    cpu: 10m
+    memory: 128Mi
+containers:
+  ui:
+    image:
+      repository: eu.gcr.io/test/ui
+      tag: v1.0.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi

--- a/tests/fixtures/helm-values-single-container.yaml
+++ b/tests/fixtures/helm-values-single-container.yaml
@@ -1,0 +1,8 @@
+containerName: test-app
+image:
+  repository: eu.gcr.io/test/test-app
+  tag: v1.0.0
+resources:
+  requests:
+    cpu: 10m
+    memory: 128Mi

--- a/tests/fixtures/statefulset.yaml
+++ b/tests/fixtures/statefulset.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  template:
+    spec:
+      containers:
+        - name: test-app
+          image: eu.gcr.io/test/test-app:v1.0.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ENVIRONMENT
+              value: production

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -35,13 +35,13 @@ run_test() {
   if [[ -n "${env_name}" ]]; then
     bash "${ENTRYPOINT}" "${mode}" "${container_name}" "${temp_file}" "" "${env_name}" "${new_value}" > /dev/null 2>&1 || {
       echo "  ❌ FAILED: Script execution failed"
-      ((TESTS_FAILED++))
+      ((TESTS_FAILED+=1))
       return 1
     }
   else
     bash "${ENTRYPOINT}" "${mode}" "${container_name}" "${temp_file}" "${new_value}" "" "" > /dev/null 2>&1 || {
       echo "  ❌ FAILED: Script execution failed"
-      ((TESTS_FAILED++))
+      ((TESTS_FAILED+=1))
       return 1
     }
   fi
@@ -49,12 +49,29 @@ run_test() {
   # Verify the result
   if grep -q "${expected_pattern}" "${temp_file}"; then
     echo "  ✅ PASSED"
-    ((TESTS_PASSED++))
+    ((TESTS_PASSED+=1))
   else
     echo "  ❌ FAILED: Expected pattern '${expected_pattern}' not found"
     echo "  File contents:"
     cat "${temp_file}"
-    ((TESTS_FAILED++))
+    ((TESTS_FAILED+=1))
+    return 1
+  fi
+}
+
+assert_yaml_value() {
+  local file="$1"
+  local expression="$2"
+  local expected_value="$3"
+  local actual_value
+
+  actual_value=$(yq4 "${expression}" "${file}")
+  if [[ "${actual_value}" == "${expected_value}" ]]; then
+    echo "  ✅ PASSED: ${expression} is ${expected_value}"
+    ((TESTS_PASSED+=1))
+  else
+    echo "  ❌ FAILED: Expected ${expression} to be ${expected_value}, got ${actual_value}"
+    ((TESTS_FAILED+=1))
     return 1
   fi
 }
@@ -122,6 +139,8 @@ run_test \
   "${FIXTURES_DIR}/helm-values-single-container.yaml" \
   "v2.0.0" \
   "tag: v2.0.0"
+assert_yaml_value "${TEMP_DIR}/helm-values-multi-container.yaml" '.image.tag' 'v2.0.0'
+assert_yaml_value "${TEMP_DIR}/helm-values-multi-container.yaml" '.containers.ui.image.tag' 'v1.0.0'
 
 # Test 8: HELM_VALUES mode - Multi-container (default container)
 run_test \
@@ -140,6 +159,8 @@ run_test \
   "${FIXTURES_DIR}/helm-values-multi-container.yaml" \
   "v3.0.0" \
   "tag: v3.0.0"
+assert_yaml_value "${TEMP_DIR}/helm-values-multi-container.yaml" '.containers.ui.image.tag' 'v3.0.0'
+assert_yaml_value "${TEMP_DIR}/helm-values-multi-container.yaml" '.image.tag' 'v1.0.0'
 
 echo ""
 echo "========================================="

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/fixtures"
+ENTRYPOINT="${SCRIPT_DIR}/../entrypoint.sh"
+TEMP_DIR=$(mktemp -d)
+
+echo "========================================="
+echo "Running gitops-action-yaml-updater tests"
+echo "========================================="
+echo ""
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Function to run a test
+run_test() {
+  local test_name="$1"
+  local mode="$2"
+  local container_name="$3"
+  local fixture_file="$4"
+  local new_value="$5"
+  local expected_pattern="$6"
+  local env_name="${7:-}"
+
+  echo "Running test: ${test_name}"
+
+  # Copy fixture to temp directory
+  local temp_file="${TEMP_DIR}/$(basename ${fixture_file})"
+  cp "${fixture_file}" "${temp_file}"
+
+  # Run the updater
+  if [[ -n "${env_name}" ]]; then
+    bash "${ENTRYPOINT}" "${mode}" "${container_name}" "${temp_file}" "" "${env_name}" "${new_value}" > /dev/null 2>&1 || {
+      echo "  ❌ FAILED: Script execution failed"
+      ((TESTS_FAILED++))
+      return 1
+    }
+  else
+    bash "${ENTRYPOINT}" "${mode}" "${container_name}" "${temp_file}" "${new_value}" "" "" > /dev/null 2>&1 || {
+      echo "  ❌ FAILED: Script execution failed"
+      ((TESTS_FAILED++))
+      return 1
+    }
+  fi
+
+  # Verify the result
+  if grep -q "${expected_pattern}" "${temp_file}"; then
+    echo "  ✅ PASSED"
+    ((TESTS_PASSED++))
+  else
+    echo "  ❌ FAILED: Expected pattern '${expected_pattern}' not found"
+    echo "  File contents:"
+    cat "${temp_file}"
+    ((TESTS_FAILED++))
+    return 1
+  fi
+}
+
+# Test 1: IMAGE_TAG mode - Deployment with single container
+run_test \
+  "IMAGE_TAG: Update Deployment single container" \
+  "IMAGE_TAG" \
+  "test-app" \
+  "${FIXTURES_DIR}/deployment-single-container.yaml" \
+  "v2.0.0" \
+  "image: eu.gcr.io/test/test-app:v2.0.0"
+
+# Test 2: IMAGE_TAG mode - Deployment with multiple containers (first container)
+run_test \
+  "IMAGE_TAG: Update Deployment multi-container (api)" \
+  "IMAGE_TAG" \
+  "api" \
+  "${FIXTURES_DIR}/deployment-multi-container.yaml" \
+  "v2.0.0" \
+  "image: eu.gcr.io/test/api:v2.0.0"
+
+# Test 3: IMAGE_TAG mode - Deployment with multiple containers (second container)
+run_test \
+  "IMAGE_TAG: Update Deployment multi-container (ui)" \
+  "IMAGE_TAG" \
+  "ui" \
+  "${FIXTURES_DIR}/deployment-multi-container.yaml" \
+  "v3.0.0" \
+  "image: eu.gcr.io/test/ui:v3.0.0"
+
+# Test 4: IMAGE_TAG mode - CronJob
+run_test \
+  "IMAGE_TAG: Update CronJob" \
+  "IMAGE_TAG" \
+  "test-cronjob" \
+  "${FIXTURES_DIR}/cronjob.yaml" \
+  "v2.0.0" \
+  "image: eu.gcr.io/test/cronjob:v2.0.0"
+
+# Test 5: IMAGE_TAG mode - StatefulSet
+run_test \
+  "IMAGE_TAG: Update StatefulSet" \
+  "IMAGE_TAG" \
+  "test-app" \
+  "${FIXTURES_DIR}/statefulset.yaml" \
+  "v2.0.0" \
+  "image: eu.gcr.io/test/test-app:v2.0.0"
+
+# Test 6: ENV_VAR mode - StatefulSet
+run_test \
+  "ENV_VAR: Update environment variable" \
+  "ENV_VAR" \
+  "test-app" \
+  "${FIXTURES_DIR}/statefulset.yaml" \
+  "staging" \
+  "value: staging" \
+  "ENVIRONMENT"
+
+# Test 7: HELM_VALUES mode - Single container (default)
+run_test \
+  "HELM_VALUES: Update default container" \
+  "HELM_VALUES" \
+  "test-app" \
+  "${FIXTURES_DIR}/helm-values-single-container.yaml" \
+  "v2.0.0" \
+  "tag: v2.0.0"
+
+# Test 8: HELM_VALUES mode - Multi-container (default container)
+run_test \
+  "HELM_VALUES: Update multi-container default (api)" \
+  "HELM_VALUES" \
+  "api" \
+  "${FIXTURES_DIR}/helm-values-multi-container.yaml" \
+  "v2.0.0" \
+  "tag: v2.0.0"
+
+# Test 9: HELM_VALUES mode - Multi-container (additional container) - THE BUG FIX TEST
+run_test \
+  "HELM_VALUES: Update multi-container additional (ui)" \
+  "HELM_VALUES" \
+  "ui" \
+  "${FIXTURES_DIR}/helm-values-multi-container.yaml" \
+  "v3.0.0" \
+  "tag: v3.0.0"
+
+echo ""
+echo "========================================="
+echo "Test Results"
+echo "========================================="
+echo "Passed: ${TESTS_PASSED}"
+echo "Failed: ${TESTS_FAILED}"
+echo ""
+
+# Cleanup
+rm -rf "${TEMP_DIR}"
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+fi
+
+echo "All tests passed! ✅"

--- a/tests/validate-syntax.sh
+++ b/tests/validate-syntax.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Simple validation script that checks bash syntax without requiring dependencies
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="${SCRIPT_DIR}/../entrypoint.sh"
+
+echo "Validating bash syntax..."
+
+# Check if entrypoint.sh exists
+if [[ ! -f "${ENTRYPOINT}" ]]; then
+  echo "❌ FAILED: entrypoint.sh not found at ${ENTRYPOINT}"
+  exit 1
+fi
+
+# Validate bash syntax
+bash -n "${ENTRYPOINT}" || {
+  echo "❌ FAILED: Syntax error in entrypoint.sh"
+  exit 1
+}
+
+echo "✅ PASSED: entrypoint.sh syntax is valid"
+
+# Check for common issues
+echo ""
+echo "Checking for common issues..."
+
+# Check if HELM_VALUES mode has proper container name handling
+if grep -A 20 'MODE.*HELM_VALUES' "${ENTRYPOINT}" | grep -q 'defaultContainerName'; then
+  echo "✅ PASSED: HELM_VALUES mode includes container name checking"
+else
+  echo "❌ WARNING: HELM_VALUES mode might not handle multiple containers correctly"
+fi
+
+# Check if targetImageKey is set for HELM_VALUES
+if grep -A 20 'MODE.*HELM_VALUES' "${ENTRYPOINT}" | grep -q 'targetImageKey'; then
+  echo "✅ PASSED: HELM_VALUES mode uses dynamic targetImageKey"
+else
+  echo "❌ WARNING: HELM_VALUES mode might use hardcoded image key"
+fi
+
+echo ""
+echo "Basic validation complete!"
+echo ""
+echo "Note: For full integration tests, run run-tests.sh with dependencies installed"
+echo "or use Docker: docker run --rm -v \$(pwd)/tests:/tests <image> bash /tests/run-tests.sh"


### PR DESCRIPTION
## Summary

HELM_VALUES now updates a named additional container without changing the default image tag. The action points to the publishable `v1.8.3` runtime image, so the fix can be delivered to callers once that image is released.

The additional-container lookup now checks the nested values map correctly, and unmatched additional container names no longer create CronJob entries.

## Validation

- `bash tests/validate-syntax.sh`
- Targeted yq v4 checks confirmed default and sidecar updates preserve the non-target image.
- Docker-backed integration tests were not run because the local Docker daemon is unavailable.
