### PR TITLE
fix: release action image v1.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ none
 
 ```yaml
 - name: Update image tag for container nginx in deployment.yaml
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.4
   with:
     mode: IMAGE_TAG
     container-name: nginx
@@ -81,7 +81,7 @@ none
 
 ```yaml
 - name: Update image tag for container bridge in two files
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.4
   with:
     mode: IMAGE_TAG
     container-name: nginx
@@ -93,7 +93,7 @@ none
 
 ```yaml
 - name: Update MY_GITHUB_SHORT_SHA env value for nginx container
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.4
   with:
     mode: ENV_VAR
     container-name: nginx
@@ -106,7 +106,7 @@ none
 
 ```yaml
 - name: Update default container image in Helm values
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.4
   with:
     mode: HELM_VALUES
     container-name: my-app
@@ -118,7 +118,7 @@ none
 
 ```yaml
 - name: Update additional container image in Helm values
-  uses: loveholidays/gitops-action-yaml-updater@v1.8.3
+  uses: loveholidays/gitops-action-yaml-updater@v1.8.4
   with:
     mode: HELM_VALUES
     container-name: sidecar-ui

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/loveholidays/gitops-action-yaml-updater:v1.8.3'
+  image: 'docker://ghcr.io/loveholidays/gitops-action-yaml-updater:v1.8.4'
   args:
     - ${{ inputs.mode }}
     - ${{ inputs.container-name }}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -139,8 +139,6 @@ run_test \
   "${FIXTURES_DIR}/helm-values-single-container.yaml" \
   "v2.0.0" \
   "tag: v2.0.0"
-assert_yaml_value "${TEMP_DIR}/helm-values-multi-container.yaml" '.image.tag' 'v2.0.0'
-assert_yaml_value "${TEMP_DIR}/helm-values-multi-container.yaml" '.containers.ui.image.tag' 'v1.0.0'
 
 # Test 8: HELM_VALUES mode - Multi-container (default container)
 run_test \
@@ -150,6 +148,8 @@ run_test \
   "${FIXTURES_DIR}/helm-values-multi-container.yaml" \
   "v2.0.0" \
   "tag: v2.0.0"
+assert_yaml_value "${TEMP_DIR}/helm-values-multi-container.yaml" '.image.tag' 'v2.0.0'
+assert_yaml_value "${TEMP_DIR}/helm-values-multi-container.yaml" '.containers.ui.image.tag' 'v1.0.0'
 
 # Test 9: HELM_VALUES mode - Multi-container (additional container) - THE BUG FIX TEST
 run_test \


### PR DESCRIPTION
Moves the Docker action runtime to the new `v1.8.4` image tag, avoiding the stale image previously published as `v1.8.3`.

Validated by running the full test suite inside the published Linux/AMD64 `v1.8.4` image: 13 passed, 0 failed.
